### PR TITLE
#166871016: Setup empty repository with webpack and babel

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -1,0 +1,1 @@
+{     "presets": ["@babel/preset-env", "@babel/preset-react"] }

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+
+package-lock.json

--- a/package.json
+++ b/package.json
@@ -1,0 +1,40 @@
+{
+  "name": "ireporter-react-frontend",
+  "version": "1.0.0",
+  "description": "A react UI approach to ireporter front end application",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1",
+    "start": "webpack-dev-server --open --hot --mode development",
+    "build": "webpack --mode production"
+  },
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/KabohaJeanMark/ireporter-react-frontend.git"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "bugs": {
+    "url": "https://github.com/KabohaJeanMark/ireporter-react-frontend/issues"
+  },
+  "homepage": "https://github.com/KabohaJeanMark/ireporter-react-frontend#readme",
+  "dependencies": {
+    "react": "^16.8.6",
+    "react-dom": "^16.8.6",
+    "react-router-dom": "^5.0.1"
+  },
+  "devDependencies": {
+    "@babel/core": "^7.4.5",
+    "@babel/preset-env": "^7.4.5",
+    "@babel/preset-react": "^7.0.0",
+    "babel-loader": "^8.0.6",
+    "css-loader": "^3.0.0",
+    "html-loader": "^0.5.5",
+    "html-webpack-plugin": "^3.2.0",
+    "style-loader": "^0.23.1",
+    "webpack": "^4.35.0",
+    "webpack-cli": "^3.3.5",
+    "webpack-dev-server": "^3.7.2"
+  }
+}

--- a/src/components/Apps/Apps.js
+++ b/src/components/Apps/Apps.js
@@ -1,0 +1,17 @@
+import React, { Component } from 'react';
+import { BrowserRouter as Router, Route} from 'react-router-dom';
+
+import Home from '../Home/Home';
+
+class App extends Component {
+
+  render(){
+    return(
+      <Router>
+          <Route exact path="/" component={Home}/>
+      </Router>
+    );
+  }
+  };
+
+export default App;

--- a/src/components/Home/Home.js
+++ b/src/components/Home/Home.js
@@ -1,0 +1,15 @@
+import React, {Component} from 'react';
+
+class Home extends Component {
+    render(){
+        return(
+            <div>
+                <h1>Welcome to Ireporter</h1>
+            </div>
+        );
+    }
+}
+
+
+export default Home;
+

--- a/src/index.html
+++ b/src/index.html
@@ -1,0 +1,16 @@
+<!DOCTYPE html>
+<!--[if lt IE 7]>      <html class="no-js lt-ie9 lt-ie8 lt-ie7"> <![endif]-->
+<!--[if IE 7]>         <html class="no-js lt-ie9 lt-ie8"> <![endif]-->
+<!--[if IE 8]>         <html class="no-js lt-ie9"> <![endif]-->
+<!--[if gt IE 8]><!--> <html class="no-js"> <!--<![endif]-->
+    <head>
+        <meta charset="utf-8">
+        <meta http-equiv="X-UA-Compatible" content="IE=edge">
+        <title>React Webpack</title>
+        <meta name="description" content="">
+        <meta name="viewport" content="width=device-width, initial-scale=1">
+    </head>
+    <body>
+        <section id="root"></section>
+    </body>
+</html>

--- a/src/index.js
+++ b/src/index.js
@@ -1,0 +1,6 @@
+import React from "react";
+import ReactDOM from "react-dom";
+
+import App from './components/Apps/Apps'; 
+
+ReactDOM.render(<App />, document.querySelector("#root"));

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,0 +1,28 @@
+const HtmlWebPackPlugin = require("html-webpack-plugin");
+module.exports = {
+  module: {
+    rules: [
+      {
+        test: /\.(js|jsx)$/,
+        exclude: /node_modules/,
+        use: {
+          loader: "babel-loader"
+        }
+      },
+      {
+        test: /\.html$/,
+        use: [
+          {
+            loader: "html-loader"
+          }
+        ]
+      }
+    ]
+  },
+  plugins: [
+    new HtmlWebPackPlugin({
+      template: "./src/index.html",
+      filename: "./index.html"
+    })
+  ]
+};


### PR DESCRIPTION
#### What does this PR do? 
This PR sets up a react project with barbel and webpack without using create-react-app tool

#### Description of tasks to be accomplished 
- installs node js and npm
- installs babel and webpack
- installs webpack dev server
- adds routing to default landing page

#### How can this PR be tested? 
Run `npm install`
Run `npm start`
You should see a message Welcome to Ireporter 

#### Screenshots if applicable
N/A

[Setup empty react project #166871016](https://www.pivotaltracker.com/story/show/166871016)